### PR TITLE
docs: 修改数组方法参数标识

### DIFF
--- a/assets/doc/02_JavaScript数据结构与算法（二）数组.md
+++ b/assets/doc/02_JavaScript数据结构与算法（二）数组.md
@@ -50,9 +50,9 @@
 
 ### 删除元素
 
-- 删除数组最后的元素 `array.pop(item)`
-- 删除数组首位的元素 `array.shift(item)`
-- 删除指定索引位置的元素 `array.splice(start, number)`
+- 删除数组最后的元素 `array.pop()`
+- 删除数组首位的元素 `array.shift()`
+- 删除指定索引位置的元素 `array.splice(start, deleteCount)`
   例如：
   ```js
   let myArray2 = [1, 2, 3, 4, 5];


### PR DESCRIPTION
- `push()` 与 `shift()` 是无参方法。
- 参考 MDN，`splice()` 使用更合适的参数名称。